### PR TITLE
[Draft] Support sign in via popup and password reset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ js-sys = ">=0.3.61"
 
 [workspace]
 members = [
-    "examples/sycamore-firebase-auth",
-    "examples/leptos-firebase-auth",
-    "examples/sycamore-realtime-database",
+    # "examples/sycamore-firebase-auth",
+    # "examples/leptos-firebase-auth",
+    # "examples/sycamore-realtime-database",
 ]
 exclude = ["examples"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ js-sys = ">=0.3.61"
 
 [workspace]
 members = [
-    # "examples/sycamore-firebase-auth",
-    # "examples/leptos-firebase-auth",
-    # "examples/sycamore-realtime-database",
+    "examples/sycamore-firebase-auth",
+    "examples/leptos-firebase-auth",
+    "examples/sycamore-realtime-database",
 ]
 exclude = ["examples"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,16 @@ readme = "README.md"
 repository = "https://github.com/wa1aric/firebase-js-rs/"
 
 [dependencies]
-wasm-bindgen = "0.2.84"
-wasm-bindgen-futures = "0.4.34"
-serde = { version = "1.0", features = ["derive"] }
-serde-wasm-bindgen = "0.4"
-js-sys = "0.3.61"
+wasm-bindgen = ">=0.2.84"
+wasm-bindgen-futures = ">=0.4.34"
+serde = { version = ">=1.0", features = ["derive"] }
+serde-wasm-bindgen = ">=0.4"
+js-sys = ">=0.3.61"
 
 [workspace]
 members = [
-    "examples/sycamore-firebase-auth",
-    "examples/leptos-firebase-auth",
-    "examples/sycamore-realtime-database",
+    # "examples/sycamore-firebase-auth",
+    # "examples/leptos-firebase-auth",
+    # "examples/sycamore-realtime-database",
 ]
-exclude = [
-    "examples"
-]
+exclude = ["examples"]

--- a/src/bindings/auth.rs
+++ b/src/bindings/auth.rs
@@ -9,6 +9,12 @@ extern "C" {
     #[wasm_bindgen(method, js_name = auth)]
     pub fn auth(_: &FirebaseApp) -> Auth;
 
+    // This gets the current user
+    #[derive(Debug)]
+    pub type User;
+    #[wasm_bindgen(method, getter, js_name = currentUser)]
+    pub fn current_user(this: &Auth) -> User;
+
     // this is for the new version of
     #[wasm_bindgen(method, js_name = onAuthStateChanged)]
     pub fn on_auth_state_changed(this: &Auth, callback: &Closure<dyn FnMut(JsValue)>);

--- a/src/bindings/auth.rs
+++ b/src/bindings/auth.rs
@@ -1,5 +1,5 @@
-use wasm_bindgen::prelude::*;
 use crate::app::FirebaseApp;
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
@@ -12,7 +12,11 @@ extern "C" {
     pub fn on_auth_state_changed(this: &Auth, callback: &Closure<dyn FnMut(JsValue)>);
 
     #[wasm_bindgen(method, catch, js_name = createUserWithEmailAndPassword)]
-    pub async fn create_user_with_email_and_password(this: &Auth, email: String, password: String) -> Result<JsValue, JsValue>;
+    pub async fn create_user_with_email_and_password(
+        this: &Auth,
+        email: String,
+        password: String,
+    ) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(catch, method, js_name = signInWithEmailAndPassword)]
     pub async fn sign_in_with_email_and_password(
@@ -23,4 +27,22 @@ extern "C" {
 
     #[wasm_bindgen(catch, method, js_name = signOut)]
     pub async fn sign_out(this: &Auth) -> Result<JsValue, JsValue>;
+
+    // Google Auth support
+    pub type GoogleAuthProvider;
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> GoogleAuthProvider;
+
+    // Github Auth support
+    pub type GithubAuthProvider;
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> GithubAuthProvider;
+
+    #[wasm_bindgen(catch, method, js_name = signInWithPopup)]
+    pub async fn sign_in_with_popup(
+        auth: &Auth,
+        provider: GoogleAuthProvider,
+    ) -> Result<JsValue, JsValue>;
 }

--- a/src/bindings/auth.rs
+++ b/src/bindings/auth.rs
@@ -27,6 +27,10 @@ extern "C" {
         password: String,
     ) -> Result<JsValue, JsValue>;
 
+    // There is an optional actionCodeSettings parameter that is not implemented here
+    #[wasm_bindgen(catch, method, js_name = sendPasswordResetEmail)]
+    pub async fn send_password_reset_email(this: &Auth, email: String) -> Result<JsValue, JsValue>;
+
     #[wasm_bindgen(catch, method, js_name = signOut)]
     pub async fn sign_out(this: &Auth) -> Result<JsValue, JsValue>;
 
@@ -37,10 +41,12 @@ extern "C" {
     pub fn new() -> GoogleAuthProvider;
 
     // Github Auth support
-    pub type GitHubAuthProvider;
+    // the name is incorrect in firebase so we have to use
+    // Github here and create another tpye alias for it
+    pub type GithubAuthProvider;
 
     #[wasm_bindgen(constructor, js_namespace = ["firebase", "auth"])]
-    pub fn new() -> GitHubAuthProvider;
+    pub fn new() -> GithubAuthProvider;
 
     #[wasm_bindgen(catch, method, js_name = signInWithPopup)]
     pub async fn sign_in_with_popup_google(
@@ -54,3 +60,6 @@ extern "C" {
         provider: &GitHubAuthProvider,
     ) -> Result<JsValue, JsValue>;
 }
+
+// type alias
+pub type GitHubAuthProvider = GithubAuthProvider;

--- a/src/bindings/auth.rs
+++ b/src/bindings/auth.rs
@@ -5,9 +5,11 @@ use wasm_bindgen::prelude::*;
 extern "C" {
     pub type Auth;
 
+    // this is for compat
     #[wasm_bindgen(method, js_name = auth)]
     pub fn auth(_: &FirebaseApp) -> Auth;
 
+    // this is for the new version of
     #[wasm_bindgen(method, js_name = onAuthStateChanged)]
     pub fn on_auth_state_changed(this: &Auth, callback: &Closure<dyn FnMut(JsValue)>);
 
@@ -31,18 +33,24 @@ extern "C" {
     // Google Auth support
     pub type GoogleAuthProvider;
 
-    #[wasm_bindgen(constructor)]
+    #[wasm_bindgen(constructor, js_namespace = ["firebase", "auth"])]
     pub fn new() -> GoogleAuthProvider;
 
     // Github Auth support
-    pub type GithubAuthProvider;
+    pub type GitHubAuthProvider;
 
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> GithubAuthProvider;
+    #[wasm_bindgen(constructor, js_namespace = ["firebase", "auth"])]
+    pub fn new() -> GitHubAuthProvider;
 
     #[wasm_bindgen(catch, method, js_name = signInWithPopup)]
-    pub async fn sign_in_with_popup(
+    pub async fn sign_in_with_popup_google(
         auth: &Auth,
-        provider: GoogleAuthProvider,
+        provider: &GoogleAuthProvider,
+    ) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(catch, method, js_name = signInWithPopup)]
+    pub async fn sign_in_with_popup_github(
+        auth: &Auth,
+        provider: &GitHubAuthProvider,
     ) -> Result<JsValue, JsValue>;
 }


### PR DESCRIPTION
Hey! Thank you for your crate. It has been helpful for me to learn a bit more about wasm-bindgen and allowing me to move off of custom js. 

I've added some functionality that I've needed for it in my own fork. Would it be helpful to merge some form of this into main? 

I also created signin popup methods for each GitHub and Google but i suspect you can use an enum `Provider` or something like that but I didn't want to mess with wasm-bindgen and figure out how to do that! 

If you'd like these in main, let me know and I'd be happy to clean it up. 

Note that the leptos examples did not work for me.

